### PR TITLE
Redesign subject / experiment save logic and corresponding GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ cython_debug/
 
 # raddeid project
 av_jambase/reenactors/raddeid_api/assets/BFM/
+
+# Output directories
+demo/Jambase/output

--- a/demo/Jambase/components/questionnaire.py
+++ b/demo/Jambase/components/questionnaire.py
@@ -3,8 +3,13 @@ from pathlib import Path
 from typing import Any, Dict
 
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (QButtonGroup, QHBoxLayout, QLabel, QPushButton,
-                               QRadioButton, QVBoxLayout)
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QHBoxLayout,
+    QLabel,
+    QRadioButton,
+    QVBoxLayout,
+)
 
 
 class Questionnaire(QVBoxLayout):
@@ -63,29 +68,8 @@ class Questionnaire(QVBoxLayout):
         label.setAlignment(Qt.AlignCenter)
         self.addWidget(label)
         self.addLayout(choices_layout)
-        self.next_btn = QPushButton("Next")
-        self.addWidget(self.next_btn, alignment=Qt.AlignRight)
 
         self.cfg = cfg
-        self.save_path = Path(cfg.get("save_path", None))
-        if self.save_path is not None:
-            if not self.save_path.exists():
-                self.save_path.mkdir(parents=True, exist_ok=True)
-            else:
-                left_save_file = self.save_path.joinpath(
-                    cfg.get("left_id", "left_questionnaire") + ".json"
-                )
-                right_save_file = self.save_path.joinpath(
-                    cfg.get("right_id", "right_questionnaire") + ".json"
-                )
-                if left_save_file.exists():
-                    raise FileExistsError(
-                        f"Save path {left_save_file} already exists. Please specify a new path."
-                    )
-                if right_save_file.exists():
-                    raise FileExistsError(
-                        f"Save path {right_save_file} already exists. Please specify a new path."
-                    )
 
         self._l_recorded = []
         self._r_recorded = []
@@ -98,16 +82,6 @@ class Questionnaire(QVBoxLayout):
 
     def record(self):
         """Record the selected choices."""
-        if self.save_path is None:
-            raise ValueError(
-                "Save path is not set. Please specify a save path in the configuration."
-            )
-        left_save_file = self.save_path.joinpath(
-            self.cfg.get("left_id", "left_questionnaire") + ".json"
-        )
-        right_save_file = self.save_path.joinpath(
-            self.cfg.get("right_id", "right_questionnaire") + ".json"
-        )
         if self.is_valid():
             left_choice = self.left_group.checkedButton()
             right_choice = self.right_group.checkedButton()
@@ -118,11 +92,17 @@ class Questionnaire(QVBoxLayout):
         else:
             raise ValueError("Both left and right choices must be selected.")
 
-        left_save_file.write_text(
-            json.dumps(self._l_recorded, indent=4, ensure_ascii=False), encoding='utf-8'
+    def save_left(self, file_path: Path):
+        """Save the selected choices."""
+
+        file_path.write_text(
+            json.dumps(self._l_recorded, indent=4, ensure_ascii=False), encoding="utf-8"
         )
-        right_save_file.write_text(
-            json.dumps(self._r_recorded, indent=4, ensure_ascii=False), encoding='utf-8'
+
+    def save_right(self, file_path: Path):
+        """Save the selected choices."""
+        file_path.write_text(
+            json.dumps(self._r_recorded, indent=4, ensure_ascii=False), encoding="utf-8"
         )
 
     def reset_question(self):

--- a/demo/Jambase/components/session_manager.py
+++ b/demo/Jambase/components/session_manager.py
@@ -1,9 +1,6 @@
-import datetime
 import random
-import string
 from pathlib import Path
 from typing import Any, Dict
-
 
 
 class AvatarSessionManager:
@@ -14,14 +11,9 @@ class AvatarSessionManager:
 
     def __init__(self, cfg: Dict[str, Any]):
         self.cfg = cfg
-        self.session_id = (
-            "".join(random.choices(string.ascii_uppercase + string.digits, k=5))
-            + "-"
-            + datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        )
         if "save_path" not in cfg:
             raise ValueError("Save path is not specified in the configuration.")
-        self.save_path = Path(cfg["save_path"]) / self.session_id
+        self.save_path = Path(cfg["save_path"])
         self.save_path.mkdir(parents=True, exist_ok=True)
 
         avatar_pools = [
@@ -69,4 +61,3 @@ class AvatarSessionManager:
         Returns True if there are more sessions, False otherwise.
         """
         return self.session_num < len(self.avatar_pools)
-

--- a/demo/Jambase/components/stream_viewer.py
+++ b/demo/Jambase/components/stream_viewer.py
@@ -1,6 +1,13 @@
-from PySide6.QtCore import Qt, QThreadPool
+from PySide6.QtCore import Qt, QThreadPool, Signal
 from PySide6.QtGui import QImage, QPixmap
-from PySide6.QtWidgets import QFrame, QLabel, QVBoxLayout
+from PySide6.QtWidgets import (
+    QFrame,
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+)
 
 import numpy as np
 import cv2
@@ -11,6 +18,8 @@ from ..utils.threads import Worker
 
 
 class StreamViewer(QVBoxLayout):
+    validityChanged = Signal(bool)
+
     def __init__(self, cam_label: str, manip_label: str):
         super().__init__()
         self.cam_view = QLabel(cam_label)
@@ -24,7 +33,24 @@ class StreamViewer(QVBoxLayout):
         self.addWidget(self.cam_view)
         self.addWidget(self.manip_view)
 
+        control_layout = QHBoxLayout()
+        control_layout.addWidget(QLabel("ID:"))
+        self.lineedit = QLineEdit()
+        self.lineedit.setPlaceholderText("Enter user ID")
+        control_layout.addWidget(self.lineedit)
+        control_layout.addStretch()
+        self.accept_btn = QPushButton("Set")
+        self.accept_btn.setEnabled(False)
+        # accept_btn.setToolTip("Set the user ID for the stream viewer.")
+        control_layout.addWidget(self.accept_btn)
+        self.addLayout(control_layout)
+
+        # Connect signals and slots
+        self.lineedit.textChanged.connect(self.on_id_changed)
+        self.accept_btn.clicked.connect(self.on_set_clicked)
+
         self.demo = None
+        self._show_demo = False
         self.cam_cap: cv2.VideoCapture = None
         self.cam_writer: cv2.VideoWriter = None
         self.manip_writer: cv2.VideoWriter = None
@@ -33,8 +59,46 @@ class StreamViewer(QVBoxLayout):
         self.manip_write_pool = QThreadPool(maxThreadCount=1)
         self.cuda_pool = QThreadPool(maxThreadCount=3)
 
+    def on_id_changed(self, text: str):
+        if self.lineedit.text().strip():
+            self.accept_btn.setEnabled(True)
+        else:
+            self.accept_btn.setEnabled(False)
+
+    def on_set_clicked(self):
+        """Handle the click event for the 'Set' button."""
+        user_id = self.lineedit.text().strip()
+        if not user_id:
+            raise ValueError("User ID cannot be empty.")
+        isvalid = self.is_valid()
+        self.lineedit.setEnabled(False)
+        if isvalid != self.is_valid():
+            self.validityChanged.emit(True)
+        self.accept_btn.setEnabled(False)
+        self.accept_btn.hide()
+
+    def is_valid(self) -> bool:
+        """Check if the user ID is valid."""
+        return not self.lineedit.isEnabled() and self.demo is not None
+
+    def set_cam_cap(self, cam_cap: cv2.VideoCapture):
+        """Set the camera capture object."""
+        self.cam_cap = cam_cap
+
+    @property
+    def user_id(self) -> str:
+        """Get the user ID for the stream viewer."""
+        return self.lineedit.text().strip()
+
+    def activate_demo(self, show: bool = True):
+        """Activate or deactivate the demo."""
+        self._show_demo = show
+
     def set_demo(self, demo: Demo):
+        isvalid = self.is_valid()
         self.demo = demo
+        if isvalid != self.is_valid():
+            self.validityChanged.emit(self.is_valid())
 
     def set_cam_writer(self, cam_writer):
         self.cam_writer = cam_writer
@@ -69,6 +133,8 @@ class StreamViewer(QVBoxLayout):
             )
         with torch.cuda.stream(torch.cuda.Stream()):
             rgb_manip = self.demo.apply(rgb_image)
+        if not self._show_demo:
+            return
         # Convert the manipulated RGB image to QImage
         rgb_manip = np.ascontiguousarray(rgb_manip)
         h, w, ch = rgb_manip.shape
@@ -86,3 +152,21 @@ class StreamViewer(QVBoxLayout):
         if self.manip_writer is not None:
             bgr_image = cv2.cvtColor(rgb_manip, cv2.COLOR_RGB2BGR)
             self.manip_write_pool.start(Worker(self.manip_writer.write, bgr_image))
+
+    def release(self):
+        """Release the camera and manipulation writers."""
+        if self.cam_writer is not None:
+            self.cam_writer.release()
+            self.cam_writer = None
+        if self.manip_writer is not None:
+            self.manip_writer.release()
+            self.manip_writer = None
+
+    def wait(self):
+        self.cam_write_pool.waitForDone()
+        self.manip_write_pool.waitForDone()
+        self.cuda_pool.waitForDone()
+
+    def stop(self):
+        self.wait()
+        self.release()

--- a/demo/Jambase/utils/files.py
+++ b/demo/Jambase/utils/files.py
@@ -1,0 +1,68 @@
+
+from pathlib import Path
+import datetime
+
+
+def get_stream_path(exp_name: str, user_id: str, root: Path, date: str = None) -> Path:
+    """
+    Get the path for the stream video file based on experiment name and user ID.
+
+    Args:
+        exp_name (str): The name of the experiment.
+        user_id (str): The ID of the user.
+
+    Returns:
+    """
+    if date is None:
+        date = datetime.datetime.now().strftime("%Y-%m-%d")
+    date = datetime.datetime.now().strftime("%Y-%m-%d")
+    return root.joinpath(f"{date}/{exp_name}-{user_id}/stream.mp4")
+
+def link_other_subject(exp_name: str, user1: str, user2: str, root: Path, date: str = None):
+    """
+    Write a text file in each subject's folder to indicate that they are linked.
+
+    Args:
+        exp_name (str): The name of the experiment.
+        user1 (str): The ID of the first user.
+        user2 (str): The ID of the second user.
+
+    """
+    if date is None:
+        date = datetime.datetime.now().strftime("%Y-%m-%d")
+    stream_1 = get_stream_path(exp_name, user1, root, date).with_name("linked_with.txt")
+    stream_2 = get_stream_path(exp_name, user2, root, date).with_name("linked_with.txt")
+    stream_1.parent.mkdir(parents=True, exist_ok=True)
+    stream_2.parent.mkdir(parents=True, exist_ok=True)
+    stream_1.write_text(f"{stream_2.parent.relative_to(root).as_posix()}\n", encoding='utf-8')
+    stream_2.write_text(f"{stream_1.parent.relative_to(root).as_posix()}\n", encoding='utf-8')
+
+
+def get_reenactment_path(exp_name: str, user_id: str, session_num: int, root: Path, date: str = None) -> Path:
+    """
+    Get the path for the reenactment video file based on experiment name, user ID, and session number.
+
+    Args:
+        exp_name (str): The name of the experiment.
+        user_id (str): The ID of the user.
+        session_num (int): The session number.
+
+    Returns:
+    """
+    if date is None:
+        date = datetime.datetime.now().strftime("%Y-%m-%d")
+    return root.joinpath(f"{date}/{exp_name}-{user_id}/reenactment-session{session_num}.mp4")
+
+def get_questionnaire_path(exp_name: str, user_id: str, root: Path, date: str = None) -> Path:
+    """
+    Get the path for the questionnaire file based on experiment name and user ID.
+
+    Args:
+        exp_name (str): The name of the experiment.
+        user_id (str): The ID of the user.
+
+    Returns:
+    """
+    if date is None:
+        date = datetime.datetime.now().strftime("%Y-%m-%d")
+    return root.joinpath(f"{date}/{exp_name}-{user_id}/questionnaire.json")


### PR DESCRIPTION
Allow the staff to set the id of the subjects and the experiment.
The save schema now 
```bash
xxxx-xx-xx # date
 |-- xxx-xx                     # experiment number - user id
 | |-- linked_with.txt          # contains the id of the other subject: yyyy-yy-yy/yyy-yy
 | |-- questionnaire.json       # contains the other subject's opinion of this subject's avatar
 | |-- stream.mp4               # camera full resolution record
 | |-- reenactment-session1.mp4 # the avatar recording of session 1
 | |-- ...
```
