### PR TITLE
Add two seesion timers

### DIFF
--- a/demo/Jambase/components/session_timer.py
+++ b/demo/Jambase/components/session_timer.py
@@ -1,0 +1,49 @@
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class StopwatchWidget(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.elapsed_time = 0  # milliseconds
+        self.running = False
+
+        self.timer = QTimer(self)
+        self.timer.setInterval(10)  # update every 10 ms
+        self.timer.timeout.connect(self.update_time)
+
+        self.label = QLabel(self.format_time(self.elapsed_time))
+        self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.label.setStyleSheet("font-size: 48px;")
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.label)
+        self.setLayout(layout)
+
+    def format_time(self, ms):
+        seconds = ms // 1000
+        minutes = seconds // 60
+        return f"{minutes%60:02}:{seconds%60:02}"
+
+    def update_time(self):
+        if self.running:
+            self.elapsed_time += 10
+            self.label.setText(self.format_time(self.elapsed_time))
+
+    def start(self):
+        if not self.running:
+            self.running = True
+            self.timer.start()
+        return self
+
+    def stop(self):
+        if self.running:
+            self.running = False
+            self.timer.stop()
+        return self
+
+    def reset(self):
+        self.stop()
+        self.elapsed_time = 0
+        self.label.setText(self.format_time(self.elapsed_time))
+        return self

--- a/demo/Jambase/main.py
+++ b/demo/Jambase/main.py
@@ -24,6 +24,7 @@ from .camera import CameraThread
 from .utils.threads import Worker
 from .components.stream_viewer import StreamViewer
 from .components.session_manager import AvatarSessionManager
+from .components.session_timer import StopwatchWidget
 from .utils import files as files_utils
 
 __dir__ = Path(__file__).resolve().parent
@@ -58,6 +59,14 @@ class MainWindow(QWidget):
         self.right_stream, right_cam = setup(2, "right")
 
         last_column_layout = QVBoxLayout()
+
+        self.session_timer = StopwatchWidget()
+        self.avatar_timer = StopwatchWidget()
+        last_column_layout.addStretch()
+        last_column_layout.addWidget(self.session_timer)
+        last_column_layout.addWidget(self.avatar_timer)
+        last_column_layout.addStretch()
+
         experiment_controls = QGroupBox("Experiment Controls")
         experiment_controls_layout = QHBoxLayout()
         experiment_controls_layout.addWidget(QLabel("Experiment"))
@@ -131,6 +140,8 @@ class MainWindow(QWidget):
 
     def on_click_start(self):
         """Start the experiment."""
+        self.session_timer.start()
+        self.avatar_timer.start()
         self.exp_textedit.setEnabled(False)
         self.start_btn.hide()
         self.next_btn.show()
@@ -186,6 +197,7 @@ class MainWindow(QWidget):
 
     def on_next_click(self):
         self.session_manager.next_session()
+        self.avatar_timer.reset().start()
 
         self.next_btn.setEnabled(False)
         QTimer.singleShot(10_000, lambda: self.next_btn.setEnabled(True))


### PR DESCRIPTION
To help the staff manage time
- Global session timer: the whole start-to-end timer.
- Avatar session timer: for each avatar.